### PR TITLE
don't use reference catalog to resolve uid

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 2.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix getObjectbyUid for nonreferenceable objects. Drops Plone 4.0 support.
+  [tschanzt]
 
 
 2.0.1 (2013-09-02)

--- a/ftw/publisher/receiver/browser/views.py
+++ b/ftw/publisher/receiver/browser/views.py
@@ -10,16 +10,16 @@ from ftw.publisher.core.interfaces import IDataCollector
 from ftw.publisher.receiver import decoder
 from ftw.publisher.receiver import getLogger
 from ftw.publisher.receiver.events import AfterCreatedEvent, AfterUpdatedEvent
+from plone.app.uuid.utils import uuidToObject
 from zope import event
 from zope.component import getAdapters
 from zope.event import notify
 from zope.lifecycleevent import ObjectAddedEvent
 from zope.publisher.interfaces import Retry
 import os.path
-import plone.uuid
 import sys
 import traceback
-
+import plone.uuid
 
 class ReceiveObject(BrowserView):
     """
@@ -404,7 +404,7 @@ class ReceiveObject(BrowserView):
         @type uid:      string
         @return:        Plone-Object or None
         """
-        return self.context.reference_catalog.lookupObject(uid)
+        return uuidToObject(uid)
 
     def _getObjectByPath(self, absolutePath):
         """


### PR DESCRIPTION
we shouldn't use the reference catalog to find the object from the uid since it can occur, that we have object which aren't referenceable and therefore not in the reference_catalog. This will cause the publisher to create a new object which will fail since we already have this object.
