### PR TITLE
Receiver response should never be transformed by diazo.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 2.0.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Diazo should never touch a response created by the receiver.
+  [mathias.leimgruber]
 
 
 2.0.2 (2013-10-28)

--- a/ftw/publisher/receiver/browser/views.py
+++ b/ftw/publisher/receiver/browser/views.py
@@ -21,6 +21,7 @@ import sys
 import traceback
 import plone.uuid
 
+
 class ReceiveObject(BrowserView):
     """
     The ReceiveObject View is called be ftw.publisher.sender module.
@@ -53,6 +54,8 @@ class ReceiveObject(BrowserView):
             resp += ''.join(traceback.format_exception(*sys.exc_info()))
         except:
             pass
+
+        self.request.RESPONSE.setHeader('X-Theme-Disabled', 'True')
         return resp
 
     def handleRequest(self):


### PR DESCRIPTION
The response could look like this.

``` html
<!DOCTYPE html> (message: <html xmlns="http://www.w3.org/1999/xhtml"><body>
<p>ObjectUpdatedState
None
</p></body></html>
```

But the sender expexts a reponse wothout doctype, etc...

@jone @lukasgraf 
