### PR TITLE
Optimize receiver

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 2.1.1 (unreleased)
 ------------------
 
+- Do not reorder if the position of the obj did not change.
+  [mathias.leimgruber]
+
 - No longer reindex getObjPositionInParent index after reordering.
   The position implementation has changes.
   [mathias.leimgruber]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 2.1.1 (unreleased)
 ------------------
 
+- Only reindex the "modified" index after setting a new modification date.
+  [mathias.leimgruber]
+
 - Do not reorder if the position of the obj did not change.
   [mathias.leimgruber]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 2.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- No longer reindex getObjPositionInParent index after reordering.
+  The position implementation has changes.
+  [mathias.leimgruber]
 
 
 2.1.0 (2015-09-30)

--- a/ftw/publisher/receiver/browser/views.py
+++ b/ftw/publisher/receiver/browser/views.py
@@ -491,6 +491,7 @@ class ReceiveObject(BrowserView):
         @type metadata:         dict
         @return:                None
         """
+
         positions = metadata['sibling_positions']
         parent = object.aq_inner.aq_parent
         object_ids = list(parent.objectIds())
@@ -505,14 +506,6 @@ class ReceiveObject(BrowserView):
 
         # order objects
         parent.moveObjectsByDelta(object_ids, -len(object_ids))
-
-        # reindex all objects
-        for id in object_ids:
-            try:
-                parent.get(id).reindexObject(
-                    idxs=['positionInParent', 'getObjPositionInParent'])
-            except:
-                pass
 
 
 class TestConnection(BrowserView):

--- a/ftw/publisher/receiver/browser/views.py
+++ b/ftw/publisher/receiver/browser/views.py
@@ -288,13 +288,15 @@ class ReceiveObject(BrowserView):
             object.setModificationDate(modifiedDate)
             if not is_root:
                 catalog_tool.catalog_object(object,
-                                            '/'.join(object.getPhysicalPath()))
+                                            '/'.join(object.getPhysicalPath()),
+                                            idxs=['modified'])
 
         if parent_modified_date:
             parent = object.aq_inner.aq_parent
             parent.setModificationDate(parent_modified_date)
             catalog_tool.catalog_object(object,
-                                        '/'.join(object.getPhysicalPath()))
+                                        '/'.join(object.getPhysicalPath()),
+                                        idxs=['modified'])
 
         # return the appropriate CommunicationState - notify events
         if new_object:

--- a/ftw/publisher/receiver/browser/views.py
+++ b/ftw/publisher/receiver/browser/views.py
@@ -495,6 +495,11 @@ class ReceiveObject(BrowserView):
         positions = metadata['sibling_positions']
         parent = object.aq_inner.aq_parent
         object_ids = list(parent.objectIds())
+        obj_id = object.getId()
+
+        # Do nothing if the position is the same.
+        if positions[obj_id] == parent.getObjectPosition(obj_id):
+            return
 
         # move objects with no position info to the bottom
         for id in object_ids:


### PR DESCRIPTION
- No longer reindex position indexes. Not necessary anymore.
- Do not reindex the position if it's not necessary (Position did not changed)
- Finally, only reindex modified index, after setting the modification date.