### PR TITLE
Use plone 5 as default when developing

### DIFF
--- a/development.cfg
+++ b/development.cfg
@@ -1,4 +1,4 @@
 [buildout]
 extends =
-    test-plone-4.3.x.cfg
+    test-plone-5.1.x.cfg
     https://raw.github.com/4teamwork/ftw-buildouts/master/plone-development.cfg


### PR DESCRIPTION
to keep the setup the same across packages