### PR TITLE
Fix request issue.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ------------------
 
 - Fix publishing to receiver on plone 5 [Nachtalb]
+- Fix request issue. [busykoala]
 
 
 2.3.0 (2019-09-05)

--- a/ftw/publisher/receiver/browser/views.py
+++ b/ftw/publisher/receiver/browser/views.py
@@ -28,12 +28,12 @@ class ReceiveObject(BrowserView):
     and runs the specified action.
     """
 
-    def __call__(self, REQUEST=None, *args, **kwargs):
+    def __call__(self, *args, **kwargs):
         """
         @return:    response string containing a representation  of a
         CommunicationState as string.
         """
-        alsoProvides(REQUEST, IDisableCSRFProtection)
+        alsoProvides(self.request, IDisableCSRFProtection)
 
         # get a logger instance
         self.logger = getLogger()


### PR DESCRIPTION
Calling `alsoProvides` with REQUEST being None raises an error. The view gets called manually and the REQUEST argument is not provided.

Since the request is provided in self.request it is not necessary to have the extra argument.