### PR TITLE
Wrap IDisableCSRFProtection import into try/except.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ------------------
 
 - Fix tests after constrained types adapter added to core. [djowett-ftw]
+- Fix IDisableCSRFProtection import error for older versions of plone.protect. [busykoala]
 
 
 2.3.2 (2019-11-27)

--- a/ftw/publisher/receiver/browser/views.py
+++ b/ftw/publisher/receiver/browser/views.py
@@ -11,7 +11,6 @@ from ftw.publisher.receiver import getLogger
 from ftw.publisher.receiver import helpers
 from ftw.publisher.receiver.events import AfterCreatedEvent, AfterUpdatedEvent
 from plone.app.uuid.utils import uuidToObject
-from plone.protect.interfaces import IDisableCSRFProtection
 from zope import event
 from zope.component import getAdapters
 from zope.interface import alsoProvides
@@ -19,6 +18,11 @@ from zope.publisher.interfaces import Retry
 import os.path
 import sys
 import traceback
+
+try:
+    from plone.protect.interfaces import IDisableCSRFProtection
+except ImportError:
+    IDisableCSRFProtection = None
 
 
 class ReceiveObject(BrowserView):
@@ -33,7 +37,8 @@ class ReceiveObject(BrowserView):
         @return:    response string containing a representation  of a
         CommunicationState as string.
         """
-        alsoProvides(self.request, IDisableCSRFProtection)
+        if IDisableCSRFProtection:
+            alsoProvides(self.request, IDisableCSRFProtection)
 
         # get a logger instance
         self.logger = getLogger()


### PR DESCRIPTION
In older version of plone.protect the interface is not available.